### PR TITLE
install OCaml 4.14.1 by default

### DIFF
--- a/haxe/config.json
+++ b/haxe/config.json
@@ -1,10 +1,10 @@
 {
 	"is64": true,
-	"ocamlVersion" : "4.09.0",
+	"ocamlVersion" : "4.14.1",
 	"cygwinTools" : ["bash", "cygpath", "$MINGW-ar", "$MINGW-as", "$MINGW-gcc", "$MINGW-ld", "$MINGW-ranlib", "ls", "make", "mkdir", "wget", "mv", "rm", "sed", "sh", "stty", "tput", "tr", "true", "cp", "m4"],
 	"mingwLibs" : ["zlib1", "libpcre2-8-0"],
 	"opamUrl" : "https://github.com/fdopen/opam-repository-mingw/releases/download/0.0.0.2/",
-	"opamLibs" : ["ocamlfind.1.9.1","sedlex","camlp5.8.00","extlib","xml-light","rope","ptmap","sha","luv.0.5.12","dune","terminal_size","ipaddr","ocaml-lsp-server","camlp-streams"],
+	"opamLibs" : ["ocamlfind.1.9.1","sedlex","extlib","xml-light","rope","ptmap","sha","luv.0.5.12","dune","terminal_size","ipaddr","ocaml-lsp-server","camlp-streams"],
 	"mingwPackages" : [
 		"https://github.com/Simn/mingw64-uv/releases/download/1.32.0/mingw64-x86_64-uv-1.32.0-1.tar.xz",
 		"https://github.com/Simn/mingw64-mbedtls/releases/download/2.16.3/mingw64-x86_64-mbedtls-2.16.3-1.tar.xz"


### PR DESCRIPTION
This should be tested on a clean system first. I saw some issue where it would try to reinstall camlp5 during the big dependency install at the end, which then caused the `# The -prefix directory must be absolute.` problem again. However, I don't really see how the current installation procedure would avoid this either.

There's some repo order juggling here because we need camlp5 from one repo but luv from another. I hope it works like that...

Closes #13